### PR TITLE
Add /stats url path redirect

### DIFF
--- a/apps/stats/app/page.test.ts
+++ b/apps/stats/app/page.test.ts
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { getStatsRedirectUrl } from "@f3muletown/redirects";
+
 import Home from "./page";
 
 vi.mock("next/navigation", () => ({
@@ -19,10 +21,10 @@ describe("stats redirect", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-07-04T15:00:00Z"));
 
+    const expectedUrl = getStatsRedirectUrl();
+
     Home();
 
-    expect(mockedRedirect).toHaveBeenCalledWith(
-      "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2024&location=f3muletown"
-    );
+    expect(mockedRedirect).toHaveBeenCalledWith(expectedUrl);
   });
 });

--- a/apps/stats/app/page.tsx
+++ b/apps/stats/app/page.tsx
@@ -1,8 +1,6 @@
 import { redirect } from "next/navigation";
+import { getStatsRedirectUrl } from "@f3muletown/redirects";
 
 export default function Home() {
-  const year = new Date().getFullYear();
-  const target = `https://www.yourfullstack.com/apps/f3fw/ytd.php?year=${year}&location=f3muletown`;
-
-  redirect(target);
+  redirect(getStatsRedirectUrl());
 }

--- a/apps/stats/e2e/redirect.spec.ts
+++ b/apps/stats/e2e/redirect.spec.ts
@@ -5,7 +5,8 @@ const statsPath = "/apps/f3fw/ytd.php";
 const currentYear = new Date().getFullYear();
 
 test("redirects homepage to the current-year stats view", async ({ page }) => {
-  await page.goto("/");
+  // Third-party assets on the target stats page can hang; only wait for the navigation to commit.
+  await page.goto("/", { waitUntil: "commit" });
 
   await page.waitForURL(
     (url) =>

--- a/apps/stats/next.config.ts
+++ b/apps/stats/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  transpilePackages: ["@f3muletown/redirects"],
 };
 
 export default nextConfig;

--- a/apps/stats/package.json
+++ b/apps/stats/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@f3muletown/redirects": "workspace:*",
     "next": "16.0.4",
     "react": "19.2.0",
     "react-dom": "19.2.0"

--- a/apps/web/app/[...slug]/page.tsx
+++ b/apps/web/app/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
-import { redirectUrl } from "@/lib/redirect";
+import { getRegionRedirectUrl } from "@f3muletown/redirects";
 
 export default function CatchAll() {
-  redirect(redirectUrl);
+  redirect(getRegionRedirectUrl());
 }

--- a/apps/web/app/page.test.ts
+++ b/apps/web/app/page.test.ts
@@ -1,9 +1,10 @@
 import { redirect } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getRegionRedirectUrl } from "@f3muletown/redirects";
+
 import CatchAll from "./[...slug]/page";
 import Home from "./page";
-import { redirectUrl } from "@/lib/redirect";
 
 vi.mock("next/navigation", () => ({
   redirect: vi.fn(),
@@ -19,12 +20,12 @@ describe("web redirects", () => {
   it("redirects the root route to the main region site", () => {
     Home();
 
-    expect(mockedRedirect).toHaveBeenCalledWith(redirectUrl);
+    expect(mockedRedirect).toHaveBeenCalledWith(getRegionRedirectUrl());
   });
 
   it("redirects catch-all routes to the main region site", () => {
     CatchAll();
 
-    expect(mockedRedirect).toHaveBeenCalledWith(redirectUrl);
+    expect(mockedRedirect).toHaveBeenCalledWith(getRegionRedirectUrl());
   });
 });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
-import { redirectUrl } from "@/lib/redirect";
+import { getRegionRedirectUrl } from "@f3muletown/redirects";
 
 export default function Home() {
-  redirect(redirectUrl);
+  redirect(getRegionRedirectUrl());
 }

--- a/apps/web/app/stats/page.test.ts
+++ b/apps/web/app/stats/page.test.ts
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getStatsRedirectUrl } from "@f3muletown/redirects";
+
+import StatsRedirect from "./page";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+const mockedRedirect = vi.mocked(redirect);
+
+describe("web stats redirect", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("redirects to the stats page for the current year", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-02T12:00:00Z"));
+
+    const expectedUrl = getStatsRedirectUrl();
+
+    StatsRedirect();
+
+    expect(mockedRedirect).toHaveBeenCalledWith(expectedUrl);
+  });
+});

--- a/apps/web/app/stats/page.tsx
+++ b/apps/web/app/stats/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+import { getStatsRedirectUrl } from "@f3muletown/redirects";
+
+export default function StatsRedirect() {
+  redirect(getStatsRedirectUrl());
+}

--- a/apps/web/e2e/redirect.spec.ts
+++ b/apps/web/e2e/redirect.spec.ts
@@ -3,8 +3,13 @@ import { expect, test } from "@playwright/test";
 const targetHost = "regions.f3nation.com";
 const targetPath = "/muletown";
 
+const statsHost = "www.yourfullstack.com";
+const statsPath = "/apps/f3fw/ytd.php";
+const statsLocation = "f3muletown";
+
 test("redirects homepage to the regions site", async ({ page }) => {
-  await page.goto("/");
+  // Some third-party assets on the target site never finish loading; wait for the navigation to commit only.
+  await page.goto("/", { waitUntil: "commit" });
 
   await page.waitForURL(
     (url) => url.host === targetHost && url.pathname.startsWith(targetPath),
@@ -16,4 +21,27 @@ test("redirects homepage to the regions site", async ({ page }) => {
   expect(url.protocol).toBe("https:");
   expect(url.host).toBe(targetHost);
   expect(url.pathname).toMatch(/^\/muletown\/?$/);
+});
+
+test("redirects /stats to the current-year stats view", async ({ page }) => {
+  const currentYear = new Date().getFullYear();
+
+  await page.goto("/stats", { waitUntil: "commit" });
+
+  await page.waitForURL(
+    (url) =>
+      url.host === statsHost &&
+      url.pathname === statsPath &&
+      url.searchParams.get("year") === String(currentYear) &&
+      url.searchParams.get("location") === statsLocation,
+    { timeout: 15_000 }
+  );
+
+  const url = new URL(page.url());
+
+  expect(url.protocol).toBe("https:");
+  expect(url.host).toBe(statsHost);
+  expect(url.pathname).toBe(statsPath);
+  expect(url.searchParams.get("year")).toBe(String(currentYear));
+  expect(url.searchParams.get("location")).toBe(statsLocation);
 });

--- a/apps/web/lib/redirect.ts
+++ b/apps/web/lib/redirect.ts
@@ -1,1 +1,0 @@
-export const redirectUrl = "https://regions.f3nation.com/muletown";

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  transpilePackages: ["@f3muletown/redirects"],
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,9 +12,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@f3muletown/redirects": "workspace:*",
+    "next": "16.0.1",
     "react": "19.2.0",
-    "react-dom": "19.2.0",
-    "next": "16.0.1"
+    "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@f3muletown/eslint-config": "workspace:*",

--- a/packages/redirects/package.json
+++ b/packages/redirects/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@f3muletown/redirects",
+  "version": "1.0.0",
+  "description": "Shared redirect helpers for f3muletown apps.",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@f3muletown/tsconfig": "workspace:*",
+    "@f3muletown/vitest-config": "workspace:*",
+    "typescript": "^5",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/redirects/src/index.test.ts
+++ b/packages/redirects/src/index.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  defaults,
+  getRegionRedirectUrl,
+  getStatsRedirectUrl,
+  redirects,
+} from "./index";
+
+describe("@f3muletown/redirects", () => {
+  describe("getRegionRedirectUrl", () => {
+    it("returns the default region redirect", () => {
+      expect(getRegionRedirectUrl()).toBe(
+        "https://regions.f3nation.com/muletown"
+      );
+    });
+
+    it("allows overriding the region slug", () => {
+      expect(getRegionRedirectUrl("nashville")).toBe(
+        "https://regions.f3nation.com/nashville"
+      );
+    });
+  });
+
+  describe("getStatsRedirectUrl", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("uses the current year and default location when not provided", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-02-15T10:00:00Z"));
+
+      expect(getStatsRedirectUrl()).toBe(
+        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2026&location=f3muletown"
+      );
+    });
+
+    it("accepts custom years and locations", () => {
+      expect(
+        getStatsRedirectUrl({ year: 2023, location: defaults.statsLocation })
+      ).toBe(
+        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2023&location=f3muletown"
+      );
+
+      expect(getStatsRedirectUrl({ year: 2025, location: "f3wherever" })).toBe(
+        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2025&location=f3wherever"
+      );
+    });
+  });
+
+  describe("redirects helper", () => {
+    it("provides a region home shortcut", () => {
+      expect(redirects.regionHome()).toBe(
+        "https://regions.f3nation.com/muletown"
+      );
+
+      expect(redirects.regionHome("nashville")).toBe(
+        "https://regions.f3nation.com/nashville"
+      );
+    });
+
+    it("provides a stats shortcut", () => {
+      expect(redirects.stats({ year: 2030, location: "f3alpha" })).toBe(
+        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2030&location=f3alpha"
+      );
+    });
+  });
+});

--- a/packages/redirects/src/index.ts
+++ b/packages/redirects/src/index.ts
@@ -1,0 +1,31 @@
+const REGION_BASE_URL = "https://regions.f3nation.com";
+const DEFAULT_REGION_SLUG = "muletown";
+
+const STATS_BASE_URL = "https://www.yourfullstack.com/apps/f3fw/ytd.php";
+const DEFAULT_STATS_LOCATION = "f3muletown";
+
+export type StatsRedirectOptions = {
+  year?: number;
+  location?: string;
+};
+
+export const defaults = {
+  regionSlug: DEFAULT_REGION_SLUG,
+  statsLocation: DEFAULT_STATS_LOCATION,
+} as const;
+
+export function getRegionRedirectUrl(slug: string = DEFAULT_REGION_SLUG) {
+  return `${REGION_BASE_URL}/${slug}`;
+}
+
+export function getStatsRedirectUrl({
+  year = new Date().getFullYear(),
+  location = DEFAULT_STATS_LOCATION,
+}: StatsRedirectOptions = {}) {
+  return `${STATS_BASE_URL}?year=${year}&location=${location}`;
+}
+
+export const redirects = {
+  regionHome: getRegionRedirectUrl,
+  stats: (options?: StatsRedirectOptions) => getStatsRedirectUrl(options),
+} as const;

--- a/packages/redirects/tsconfig.json
+++ b/packages/redirects/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@f3muletown/tsconfig/base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/redirects/vitest.config.mts
+++ b/packages/redirects/vitest.config.mts
@@ -1,0 +1,10 @@
+import baseConfig from "@f3muletown/vitest-config";
+import { mergeConfig } from "vitest/config";
+
+export default mergeConfig(baseConfig, {
+  test: {
+    coverage: {
+      include: ["src/**/*.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/stats:
     dependencies:
+      '@f3muletown/redirects':
+        specifier: workspace:*
+        version: link:../../packages/redirects
       next:
         specifier: 16.0.4
         version: 16.0.4(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -96,6 +99,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@f3muletown/redirects':
+        specifier: workspace:*
+        version: link:../../packages/redirects
       next:
         specifier: 16.0.1
         version: 16.0.1(@playwright/test@1.57.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -162,6 +168,21 @@ importers:
         version: 16.0.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
 
   packages/prettier-config: {}
+
+  packages/redirects:
+    devDependencies:
+      '@f3muletown/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@f3muletown/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@20.19.25)(jsdom@26.1.0)(lightningcss@1.30.2)
 
   packages/tsconfig: {}
 
@@ -4185,7 +4206,7 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -4204,7 +4225,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.4
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -4224,7 +4245,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.4
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -4247,7 +4268,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.1(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4262,29 +4298,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.1(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4309,7 +4330,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4327,7 +4348,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4339,6 +4360,33 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
... (in addition to the existing `stats.` subdomain redirect)

<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

<!-- keep it simple, a sentence or two at most -->

Created new `@f3muletown/redirects` package with shared redirect utilities and added `/stats` route to web app for consistent redirection.

### 🔎 Details

<!--
This is the place to get in the weeds about what changed.
Consider linking out to project artifacts like:
- Jira issue(s)
- Slack post(s)
- Loom video(s)
- Figma design(s)
- etc.
-->

- Created new `@f3muletown/redirects` package with TypeScript config, Vitest setup, and test suite
- Added `getRegionRedirectUrl` and `getStatsRedirectUrl` utility functions
- Added `/stats` route to web app with proper testing and E2E coverage
- Updated both `stats` and `web` apps to use shared redirect package instead of local implementations
- Removed legacy `redirect.ts` file from web app
- Configured Next.js transpilation for the shared redirects package in both apps
- Improved E2E test reliability by using `waitUntil: "commit"` to avoid third-party asset timeouts

### ✅ How to Test

<!--
Document what a real testing looks like.
Think not only about code review,
but also about QA/UAT.
Given-When-Then acceptance criteria are great,
but even just a flat list of common test cases
in common language is better than nothing
-->

1. **Package Tests**: Run `pnpm test` in the redirects package to verify utility functions
2. **Web App Redirects**:
   - Navigate to `/` - should redirect to `https://regions.f3nation.com/muletown`
   - Navigate to `/stats` - should redirect to current year stats with location `f3muletown`
   - Navigate to any unknown route (e.g., `/about`) - should redirect to region home
3. **Stats App Redirect**:
   - Navigate to `/` - should redirect to current year stats with location `f3muletown`
4. **E2E Tests**: Run `pnpm test:e2e` in both apps to verify end-to-end redirect behavior
5. **Integration**: Verify both apps build successfully with the shared redirect package

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
