### PR TITLE
Update stats redirect URL to use F3 Nation's Pax Vault

### DIFF
--- a/packages/redirects/src/index.test.ts
+++ b/packages/redirects/src/index.test.ts
@@ -1,11 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import {
-  defaults,
-  getRegionRedirectUrl,
-  getStatsRedirectUrl,
-  redirects,
-} from "./index";
+import { getRegionRedirectUrl, getStatsRedirectUrl, redirects } from "./index";
 
 describe("@f3muletown/redirects", () => {
   describe("getRegionRedirectUrl", () => {
@@ -23,28 +18,9 @@ describe("@f3muletown/redirects", () => {
   });
 
   describe("getStatsRedirectUrl", () => {
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("uses the current year and default location when not provided", () => {
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-02-15T10:00:00Z"));
-
+    it("returns the stats redirect URL", () => {
       expect(getStatsRedirectUrl()).toBe(
-        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2026&location=f3muletown"
-      );
-    });
-
-    it("accepts custom years and locations", () => {
-      expect(
-        getStatsRedirectUrl({ year: 2023, location: defaults.statsLocation })
-      ).toBe(
-        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2023&location=f3muletown"
-      );
-
-      expect(getStatsRedirectUrl({ year: 2025, location: "f3wherever" })).toBe(
-        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2025&location=f3wherever"
+        "https://pax-vault.f3nation.com/stats/region/35838"
       );
     });
   });
@@ -61,8 +37,8 @@ describe("@f3muletown/redirects", () => {
     });
 
     it("provides a stats shortcut", () => {
-      expect(redirects.stats({ year: 2030, location: "f3alpha" })).toBe(
-        "https://www.yourfullstack.com/apps/f3fw/ytd.php?year=2030&location=f3alpha"
+      expect(redirects.stats()).toBe(
+        "https://pax-vault.f3nation.com/stats/region/35838"
       );
     });
   });

--- a/packages/redirects/src/index.ts
+++ b/packages/redirects/src/index.ts
@@ -1,31 +1,21 @@
 const REGION_BASE_URL = "https://regions.f3nation.com";
 const DEFAULT_REGION_SLUG = "muletown";
 
-const STATS_BASE_URL = "https://www.yourfullstack.com/apps/f3fw/ytd.php";
-const DEFAULT_STATS_LOCATION = "f3muletown";
-
-export type StatsRedirectOptions = {
-  year?: number;
-  location?: string;
-};
+const STATS_URL = "https://pax-vault.f3nation.com/stats/region/35838";
 
 export const defaults = {
   regionSlug: DEFAULT_REGION_SLUG,
-  statsLocation: DEFAULT_STATS_LOCATION,
 } as const;
 
 export function getRegionRedirectUrl(slug: string = DEFAULT_REGION_SLUG) {
   return `${REGION_BASE_URL}/${slug}`;
 }
 
-export function getStatsRedirectUrl({
-  year = new Date().getFullYear(),
-  location = DEFAULT_STATS_LOCATION,
-}: StatsRedirectOptions = {}) {
-  return `${STATS_BASE_URL}?year=${year}&location=${location}`;
+export function getStatsRedirectUrl() {
+  return STATS_URL;
 }
 
 export const redirects = {
   regionHome: getRegionRedirectUrl,
-  stats: (options?: StatsRedirectOptions) => getStatsRedirectUrl(options),
+  stats: getStatsRedirectUrl,
 } as const;


### PR DESCRIPTION
<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Updated the stats redirect URL to use F3 Nation's Pax Vault system instead of the previous dynamic URL format.

### 🔎 Details

The stats redirect URL has been updated from its previous format to point to F3 Nation's official Pax Vault system. This change replaces the old URL with the new static Pax Vault URL.

### ✅ How to Test

1. **Verify the new stats URL is correct:**
   - Navigate to `https://pax-vault.f3nation.com/stats/region/35838` to confirm it loads the regional stats page.

2. **Test the API changes:**
   - Call `getStatsRedirectUrl()` - should return the static Pax Vault URL
   - Call `redirects.stats()` - should return the same static Pax Vault URL

3. **Run existing tests:**
   - Execute the test suite to ensure all tests pass with the updated implementation

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
