### PR TITLE
Fix E2E Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # F3 Muletown
 
+random change to trigger ci build
+
 Monorepo for two small Next.js apps that route traffic to the right F3 Muletown destinations.
 
 ## Apps & ports

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # F3 Muletown
 
-random change to trigger ci build
-
 Monorepo for two small Next.js apps that route traffic to the right F3 Muletown destinations.
 
 ## Apps & ports

--- a/apps/stats/e2e/redirect.spec.ts
+++ b/apps/stats/e2e/redirect.spec.ts
@@ -1,19 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-const statsHost = "www.yourfullstack.com";
-const statsPath = "/apps/f3fw/ytd.php";
-const currentYear = new Date().getFullYear();
+const statsHost = "pax-vault.f3nation.com";
+const statsPath = "/stats/region/35838";
 
-test("redirects homepage to the current-year stats view", async ({ page }) => {
+test("redirects homepage to the stats page", async ({ page }) => {
   // Third-party assets on the target stats page can hang; only wait for the navigation to commit.
   await page.goto("/", { waitUntil: "commit" });
 
   await page.waitForURL(
-    (url) =>
-      url.host === statsHost &&
-      url.pathname === statsPath &&
-      url.searchParams.get("year") === String(currentYear) &&
-      url.searchParams.get("location") === "f3muletown",
+    (url) => url.host === statsHost && url.pathname === statsPath,
     { timeout: 15_000 }
   );
 
@@ -22,6 +17,4 @@ test("redirects homepage to the current-year stats view", async ({ page }) => {
   expect(url.protocol).toBe("https:");
   expect(url.host).toBe(statsHost);
   expect(url.pathname).toBe(statsPath);
-  expect(url.searchParams.get("year")).toBe(String(currentYear));
-  expect(url.searchParams.get("location")).toBe("f3muletown");
 });

--- a/apps/web/e2e/redirect.spec.ts
+++ b/apps/web/e2e/redirect.spec.ts
@@ -3,9 +3,8 @@ import { expect, test } from "@playwright/test";
 const targetHost = "regions.f3nation.com";
 const targetPath = "/muletown";
 
-const statsHost = "www.yourfullstack.com";
-const statsPath = "/apps/f3fw/ytd.php";
-const statsLocation = "f3muletown";
+const statsHost = "pax-vault.f3nation.com";
+const statsPath = "/stats/region/35838";
 
 test("redirects homepage to the regions site", async ({ page }) => {
   // Some third-party assets on the target site never finish loading; wait for the navigation to commit only.
@@ -23,17 +22,11 @@ test("redirects homepage to the regions site", async ({ page }) => {
   expect(url.pathname).toMatch(/^\/muletown\/?$/);
 });
 
-test("redirects /stats to the current-year stats view", async ({ page }) => {
-  const currentYear = new Date().getFullYear();
-
+test("redirects /stats to the stats page", async ({ page }) => {
   await page.goto("/stats", { waitUntil: "commit" });
 
   await page.waitForURL(
-    (url) =>
-      url.host === statsHost &&
-      url.pathname === statsPath &&
-      url.searchParams.get("year") === String(currentYear) &&
-      url.searchParams.get("location") === statsLocation,
+    (url) => url.host === statsHost && url.pathname === statsPath,
     { timeout: 15_000 }
   );
 
@@ -42,6 +35,4 @@ test("redirects /stats to the current-year stats view", async ({ page }) => {
   expect(url.protocol).toBe("https:");
   expect(url.host).toBe(statsHost);
   expect(url.pathname).toBe(statsPath);
-  expect(url.searchParams.get("year")).toBe(String(currentYear));
-  expect(url.searchParams.get("location")).toBe(statsLocation);
 });


### PR DESCRIPTION
split from https://github.com/pstaylor-patrick/f3muletown/pull/13

<!--
Learn more about GitHub Pull Request Templates at...
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
-->
<!--
### 🚧 This PR is Part of a Series
-->
<!--
You can simply remove this section
if you don't need it for your use-case
(e.g., a one-off PR that isn't actually
stacked or part of a series)
-->
<!--
- #1 short description
- #2 short description
- #3 short description
-->

### 👋 TL;DR

Updated the redirect endpoints for both the stats and web applications to point to a new F3 Nation stats host and simplified path, removing year and location query parameters.

### 🔎 Details

The redirect logic in both the `stats` and `web` applications has been updated to use a new centralized stats host (`pax-vault.f3nation.com`) with a static regional path (`/stats/region/35838`). Previously, the redirects pointed to `www.yourfullstack.com` with dynamic query parameters for `year` and `location`. The changes simplify the redirect targets and remove the dependency on generating the current year and specific location codes.

Key changes:
- Updated `statsHost` from `www.yourfullstack.com` to `pax-vault.f3nation.com`
- Updated `statsPath` from `/apps/f3fw/ytd.php` to `/stats/region/35838`
- Removed all logic related to `currentYear` and `location` query parameters
- Simplified test descriptions and validation logic to match the new static redirect targets
- Both the homepage redirect (in stats app) and the `/stats` path redirect (in web app) now point to the same simplified endpoint

### ✅ How to Test

1. **Run the updated E2E tests** for both applications to verify the redirects work correctly:
   - Navigate to the stats app directory and run: `npm run test:e2e`
   - Navigate to the web app directory and run: `npm run test:e2e`
   - Both test suites should pass, confirming the redirects to the new host and path.

2. **Manual verification of redirects**:
   - **Stats App**: Visit the homepage of the stats application. It should redirect to `https://pax-vault.f3nation.com/stats/region/35838` without any query parameters.
   - **Web App**:
     - Visit the homepage of the web application. It should still redirect to `https://regions.f3nation.com/muletown` (unchanged).
     - Visit the `/stats` path of the web application. It should redirect to `https://pax-vault.f3nation.com/stats/region/35838` without any query parameters.

3. **Verify no regression**:
   - Ensure the web app homepage redirect to the regions site still functions correctly.
   - Confirm that all redirects use HTTPS protocol.

### 🥜 GIF

<!-- GIFs are always optional but never forgotten -->

![lack-of-hustle](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWZ2enV5YXY5YXdzb2IwOWFtMGp1OTd0bGljdHBzNXpiYXVzM2Y2ZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPACZEWen2eaBm8/giphy.gif)
